### PR TITLE
add frequency input to rust API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 - Alan Zhou
 - Caleb Carpenter
 - Anders Bahrami
+- Alex Zhang

--- a/digital_instruments_api/src/lib.rs
+++ b/digital_instruments_api/src/lib.rs
@@ -21,7 +21,8 @@ use cpal::{Stream, Sample, FromSample, SizedSample};
 pub struct Handle(Stream);
 
 #[wasm_bindgen]
-pub fn beep() -> Handle {
+pub fn beep(freq_input: Option<f32>) -> Handle {
+    let freq = freq_input.unwrap_or(440.0);
     let host = cpal::default_host();
     let device = host
         .default_output_device()
@@ -29,14 +30,14 @@ pub fn beep() -> Handle {
     let config = device.default_output_config().unwrap();
 
     Handle(match config.sample_format() {
-        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()),
-        cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()),
-        cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()),
+        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into(), freq),
+        cpal::SampleFormat::I16 => run::<i16>(&device, &config.into(), freq),
+        cpal::SampleFormat::U16 => run::<u16>(&device, &config.into(), freq),
         _ => todo!(),
     })
 }
 
-fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Stream
+fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig, freq: f32) -> Stream
 where
     T: SizedSample + FromSample<f32>,
 {
@@ -47,7 +48,7 @@ where
     let mut sample_clock = 0f32;
     let mut next_value = move || {
         sample_clock = (sample_clock + 1.0) % sample_rate;
-        (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
+        (sample_clock * freq * 2.0 * 3.141592 / sample_rate).sin()
     };
 
     let err_fn = |err| console::error_1(&format!("an error occurred on stream: {}", err).into());

--- a/digital_instruments_api/src/lib.rs
+++ b/digital_instruments_api/src/lib.rs
@@ -37,6 +37,24 @@ pub fn beep(freq_input: Option<f32>) -> Handle {
     })
 }
 
+#[wasm_bindgen]
+pub fn play_note(note_input: Option<f32>) -> Handle {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .expect("failed to find a default output device");
+    let config = device.default_output_config().unwrap();
+
+    let freq = 440.0 * f32::powf(2.0, note_input.unwrap_or(0.0) / 12.0);
+
+    Handle(match config.sample_format() {
+        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into(), freq),
+        cpal::SampleFormat::I16 => run::<i16>(&device, &config.into(), freq),
+        cpal::SampleFormat::U16 => run::<u16>(&device, &config.into(), freq),
+        _ => todo!(),
+    })
+}
+
 fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig, freq: f32) -> Stream
 where
     T: SizedSample + FromSample<f32>,

--- a/digital_instruments_frontend/src/Instrument.js
+++ b/digital_instruments_frontend/src/Instrument.js
@@ -8,7 +8,8 @@ class Instrument extends Component {
     }
 
     startBeep = () => {
-        this.state.handles.push(instrument.beep());
+        this.state.handles.push(instrument.play_note(0)); // plays A4 (440Hz)
+        // integer step is one step
     }
     
     stopBeep = () => {


### PR DESCRIPTION
add extra optional parameter to beep wasm function that later gets passed into run
```rust
pub fn beep(freq_input: Option<f32>) -> Handle {
    let freq = freq_input.unwrap_or(440.0);
```